### PR TITLE
Refactor hooktest to use shared execute helper

### DIFF
--- a/crates/hooktest/src/execute.rs
+++ b/crates/hooktest/src/execute.rs
@@ -1,0 +1,86 @@
+use crate::output::Output;
+use anyhow::Result;
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+/// Spawn a hook process, feed it the given JSON input, and print execution details.
+///
+/// Returns the parsed JSON output if the process succeeded and produced valid JSON.
+pub fn execute_hook(
+    out: &mut Output,
+    hook_args: &[String],
+    input_json: &str,
+    hook_input_value: &serde_json::Value,
+) -> Result<Option<serde_json::Value>> {
+    if hook_args.is_empty() {
+        anyhow::bail!("No hook command provided. Use -- followed by the hook command.");
+    }
+
+    let mut cmd = Command::new(&hook_args[0]);
+    if hook_args.len() > 1 {
+        cmd.args(&hook_args[1..]);
+    }
+
+    out.h1("Running Hook")?;
+    out.label(
+        "Command",
+        &format!("{} {}", hook_args[0], hook_args[1..].join(" ")),
+    )?;
+
+    out.h1("Input JSON")?;
+    out.json(hook_input_value)?;
+
+    out.h1("Execution")?;
+
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(input_json.as_bytes())?;
+        stdin.flush()?;
+    }
+
+    let output = child.wait_with_output()?;
+
+    let exit_code = output.status.code().unwrap_or(-1);
+    if output.status.success() {
+        out.label("Exit Code", &format!("{exit_code} "))?;
+        out.success("✓")?;
+        out.newline()?;
+    } else {
+        out.label("Exit Code", &format!("{exit_code} "))?;
+        out.error("✗")?;
+        out.newline()?;
+    }
+
+    if !output.stdout.is_empty() {
+        out.h1("STDOUT")?;
+        out.block(String::from_utf8_lossy(&output.stdout).trim_end())?;
+    }
+
+    if !output.stderr.is_empty() {
+        out.h1("STDERR")?;
+        out.dimmed(String::from_utf8_lossy(&output.stderr).trim_end())?;
+    }
+
+    if output.status.success() && !output.stdout.is_empty() {
+        match serde_json::from_slice::<serde_json::Value>(&output.stdout) {
+            Ok(json) => {
+                out.h1("Hook Output (Parsed)")?;
+                out.json(&json)?;
+                return Ok(Some(json));
+            }
+            Err(e) => {
+                out.h1("Hook Output (Raw - Failed to parse)")?;
+                out.block(String::from_utf8_lossy(&output.stdout).trim_end())?;
+                out.error(&format!("Parse error: {e}"))?;
+                out.newline()?;
+            }
+        }
+    }
+
+    Ok(None)
+}

--- a/crates/hooktest/src/main.rs
+++ b/crates/hooktest/src/main.rs
@@ -1,3 +1,4 @@
+mod execute;
 mod notification;
 mod output;
 mod posttool;

--- a/crates/hooktest/src/notification.rs
+++ b/crates/hooktest/src/notification.rs
@@ -1,7 +1,6 @@
+use crate::execute::execute_hook;
 use crate::output::Output;
 use anyhow::Result;
-use std::io::Write;
-use std::process::{Command, Stdio};
 use tenx_hooks::Notification;
 
 pub fn run_notification_hook(
@@ -24,94 +23,29 @@ pub fn run_notification_hook(
     // Serialize to JSON
     let input_json = serde_json::to_string(&hook_input)?;
 
-    // Execute the hook
-    if hook_args.is_empty() {
-        anyhow::bail!("No hook command provided. Use -- followed by the hook command.");
-    }
+    // Execute the hook and parse output
+    if let Some(hook_output) = execute_hook(
+        &mut out,
+        &hook_args,
+        &input_json,
+        &serde_json::to_value(&hook_input)?,
+    )? {
+        out.h1("What Claude/User Would See")?;
 
-    let mut cmd = Command::new(&hook_args[0]);
-    if hook_args.len() > 1 {
-        cmd.args(&hook_args[1..]);
-    }
-
-    out.h1("Running Hook")?;
-    out.label(
-        "Command",
-        &format!("{} {}", hook_args[0], hook_args[1..].join(" ")),
-    )?;
-
-    out.h1("Input JSON")?;
-    out.json(&serde_json::to_value(&hook_input)?)?;
-
-    out.h1("Execution")?;
-
-    let mut child = cmd
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    // Write input to stdin
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin.write_all(input_json.as_bytes())?;
-        stdin.flush()?;
-    }
-
-    // Wait for the process to complete
-    let output = child.wait_with_output()?;
-
-    let exit_code = output.status.code().unwrap_or(-1);
-    if output.status.success() {
-        out.label("Exit Code", &format!("{exit_code} "))?;
-        out.success("✓")?;
-        out.newline()?;
-    } else {
-        out.label("Exit Code", &format!("{exit_code} "))?;
-        out.error("✗")?;
-        out.newline()?;
-    }
-
-    if !output.stdout.is_empty() {
-        out.h1("STDOUT")?;
-        out.block(String::from_utf8_lossy(&output.stdout).trim_end())?;
-    }
-
-    if !output.stderr.is_empty() {
-        out.h1("STDERR")?;
-        out.dimmed(String::from_utf8_lossy(&output.stderr).trim_end())?;
-    }
-
-    // Parse the output if successful
-    if output.status.success() && !output.stdout.is_empty() {
-        match serde_json::from_slice::<serde_json::Value>(&output.stdout) {
-            Ok(hook_output) => {
-                out.h1("Hook Output (Parsed)")?;
-                out.json(&hook_output)?;
-
-                out.h1("What Claude/User Would See")?;
-
-                // Check continue field
-                if hook_output.get("continue").and_then(|c| c.as_bool()) == Some(false) {
-                    out.error("Claude would STOP processing")?;
-                    out.newline()?;
-                    if let Some(reason) = hook_output.get("stopReason").and_then(|r| r.as_str()) {
-                        out.label("Stop reason shown to user", reason)?;
-                    }
-                } else {
-                    out.dimmed("Claude continues normally")?;
-                }
-
-                if hook_output.get("suppressOutput").and_then(|s| s.as_bool()) == Some(true) {
-                    out.newline()?;
-                    out.dimmed("Output would be hidden in transcript mode")?;
-                }
+        // Check continue field
+        if hook_output.get("continue").and_then(|c| c.as_bool()) == Some(false) {
+            out.error("Claude would STOP processing")?;
+            out.newline()?;
+            if let Some(reason) = hook_output.get("stopReason").and_then(|r| r.as_str()) {
+                out.label("Stop reason shown to user", reason)?;
             }
-            Err(e) => {
-                out.h1("Hook Output (Raw - Failed to parse)")?;
-                out.block(String::from_utf8_lossy(&output.stdout).trim_end())?;
-                out.error(&format!("Parse error: {e}"))?;
-                out.newline()?;
-            }
+        } else {
+            out.dimmed("Claude continues normally")?;
+        }
+
+        if hook_output.get("suppressOutput").and_then(|s| s.as_bool()) == Some(true) {
+            out.newline()?;
+            out.dimmed("Output would be hidden in transcript mode")?;
         }
     }
 

--- a/crates/hooktest/src/posttool.rs
+++ b/crates/hooktest/src/posttool.rs
@@ -1,8 +1,7 @@
+use crate::execute::execute_hook;
 use crate::output::Output;
 use anyhow::Result;
 use std::collections::HashMap;
-use std::io::Write;
-use std::process::{Command, Stdio};
 use tenx_hooks::PostToolUse;
 
 pub fn run_posttooluse_hook(
@@ -32,117 +31,48 @@ pub fn run_posttooluse_hook(
     // Serialize to JSON
     let input_json = serde_json::to_string(&hook_input)?;
 
-    // Execute the hook
-    if hook_args.is_empty() {
-        anyhow::bail!("No hook command provided. Use -- followed by the hook command.");
-    }
+    // Execute the hook and parse output
+    if let Some(hook_output) = execute_hook(
+        &mut out,
+        &hook_args,
+        &input_json,
+        &serde_json::to_value(&hook_input)?,
+    )? {
+        out.h1("What Claude/User Would See")?;
 
-    let mut cmd = Command::new(&hook_args[0]);
-    if hook_args.len() > 1 {
-        cmd.args(&hook_args[1..]);
-    }
-
-    out.h1("Running Hook")?;
-    out.label(
-        "Command",
-        &format!("{} {}", hook_args[0], hook_args[1..].join(" ")),
-    )?;
-
-    out.h1("Input JSON")?;
-    out.json(&serde_json::to_value(&hook_input)?)?;
-
-    out.h1("Execution")?;
-
-    let mut child = cmd
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    // Write input to stdin
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin.write_all(input_json.as_bytes())?;
-        stdin.flush()?;
-    }
-
-    // Wait for the process to complete
-    let output = child.wait_with_output()?;
-
-    let exit_code = output.status.code().unwrap_or(-1);
-    if output.status.success() {
-        out.label("Exit Code", &format!("{exit_code} "))?;
-        out.success("✓")?;
-        out.newline()?;
-    } else {
-        out.label("Exit Code", &format!("{exit_code} "))?;
-        out.error("✗")?;
-        out.newline()?;
-    }
-
-    if !output.stdout.is_empty() {
-        out.h1("STDOUT")?;
-        out.block(String::from_utf8_lossy(&output.stdout).trim_end())?;
-    }
-
-    if !output.stderr.is_empty() {
-        out.h1("STDERR")?;
-        out.dimmed(String::from_utf8_lossy(&output.stderr).trim_end())?;
-    }
-
-    // Parse the output if successful
-    if output.status.success() && !output.stdout.is_empty() {
-        match serde_json::from_slice::<serde_json::Value>(&output.stdout) {
-            Ok(hook_output) => {
-                out.h1("Hook Output (Parsed)")?;
-                out.json(&hook_output)?;
-
-                out.h1("What Claude/User Would See")?;
-
-                // Parse decision field
-                if let Some(decision) = hook_output.get("decision").and_then(|d| d.as_str()) {
-                    match decision {
-                        "block" => {
-                            out.write("Decision: ")?;
-                            out.error("BLOCK")?;
-                            out.newline()?;
-
-                            if let Some(reason) = hook_output.get("reason").and_then(|r| r.as_str())
-                            {
-                                out.label(
-                                    "User sees",
-                                    "Tool succeeded, but hook provided feedback",
-                                )?;
-                                out.label("Claude sees", reason)?;
-                            }
-                        }
-                        _ => {
-                            out.label("Decision", &format!("Unknown ({decision})"))?;
-                        }
-                    }
-                } else {
-                    out.dimmed("Decision: NONE (tool output passed through)")?;
-                }
-
-                if hook_output.get("continue").and_then(|c| c.as_bool()) == Some(false) {
+        // Parse decision field
+        if let Some(decision) = hook_output.get("decision").and_then(|d| d.as_str()) {
+            match decision {
+                "block" => {
+                    out.write("Decision: ")?;
+                    out.error("BLOCK")?;
                     out.newline()?;
-                    out.error("Claude would STOP processing")?;
-                    out.newline()?;
-                    if let Some(reason) = hook_output.get("stopReason").and_then(|r| r.as_str()) {
-                        out.label("Stop reason shown to user", reason)?;
+
+                    if let Some(reason) = hook_output.get("reason").and_then(|r| r.as_str()) {
+                        out.label("User sees", "Tool succeeded, but hook provided feedback")?;
+                        out.label("Claude sees", reason)?;
                     }
                 }
-
-                if hook_output.get("suppressOutput").and_then(|s| s.as_bool()) == Some(true) {
-                    out.newline()?;
-                    out.dimmed("Output would be hidden in transcript mode")?;
+                _ => {
+                    out.label("Decision", &format!("Unknown ({decision})"))?;
                 }
             }
-            Err(e) => {
-                out.h1("Hook Output (Raw - Failed to parse)")?;
-                out.block(String::from_utf8_lossy(&output.stdout).trim_end())?;
-                out.error(&format!("Parse error: {e}"))?;
-                out.newline()?;
+        } else {
+            out.dimmed("Decision: NONE (tool output passed through)")?;
+        }
+
+        if hook_output.get("continue").and_then(|c| c.as_bool()) == Some(false) {
+            out.newline()?;
+            out.error("Claude would STOP processing")?;
+            out.newline()?;
+            if let Some(reason) = hook_output.get("stopReason").and_then(|r| r.as_str()) {
+                out.label("Stop reason shown to user", reason)?;
             }
+        }
+
+        if hook_output.get("suppressOutput").and_then(|s| s.as_bool()) == Some(true) {
+            out.newline()?;
+            out.dimmed("Output would be hidden in transcript mode")?;
         }
     }
 

--- a/crates/hooktest/src/pretool.rs
+++ b/crates/hooktest/src/pretool.rs
@@ -1,8 +1,7 @@
+use crate::execute::execute_hook;
 use crate::output::Output;
 use anyhow::Result;
 use std::collections::HashMap;
-use std::io::Write;
-use std::process::{Command, Stdio};
 use tenx_hooks::PreToolUse;
 
 pub fn run_pretooluse_hook(
@@ -28,119 +27,52 @@ pub fn run_pretooluse_hook(
     // Serialize to JSON
     let input_json = serde_json::to_string(&hook_input)?;
 
-    // Execute the hook
-    if hook_args.is_empty() {
-        anyhow::bail!("No hook command provided. Use -- followed by the hook command.");
-    }
+    // Execute the hook and parse output
+    if let Some(hook_output) = execute_hook(
+        &mut out,
+        &hook_args,
+        &input_json,
+        &serde_json::to_value(&hook_input)?,
+    )? {
+        out.h1("What Claude/User Would See")?;
 
-    let mut cmd = Command::new(&hook_args[0]);
-    if hook_args.len() > 1 {
-        cmd.args(&hook_args[1..]);
-    }
+        // Parse decision field
+        if let Some(decision) = hook_output.get("decision").and_then(|d| d.as_str()) {
+            match decision {
+                "approve" => {
+                    out.write("Decision: ")?;
+                    out.success("APPROVE")?;
+                    out.newline()?;
 
-    out.h1("Running Hook")?;
-    out.label(
-        "Command",
-        &format!("{} {}", hook_args[0], hook_args[1..].join(" ")),
-    )?;
-
-    out.h1("Input JSON")?;
-    out.json(&serde_json::to_value(&hook_input)?)?;
-
-    out.h1("Execution")?;
-
-    let mut child = cmd
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    // Write input to stdin
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin.write_all(input_json.as_bytes())?;
-        stdin.flush()?;
-    }
-
-    // Wait for the process to complete
-    let output = child.wait_with_output()?;
-
-    let exit_code = output.status.code().unwrap_or(-1);
-    if output.status.success() {
-        out.label("Exit Code", &format!("{exit_code} "))?;
-        out.success("✓")?;
-        out.newline()?;
-    } else {
-        out.label("Exit Code", &format!("{exit_code} "))?;
-        out.error("✗")?;
-        out.newline()?;
-    }
-
-    if !output.stdout.is_empty() {
-        out.h1("STDOUT")?;
-        out.block(String::from_utf8_lossy(&output.stdout).trim_end())?;
-    }
-
-    if !output.stderr.is_empty() {
-        out.h1("STDERR")?;
-        out.dimmed(String::from_utf8_lossy(&output.stderr).trim_end())?;
-    }
-
-    // Parse the output if successful
-    if output.status.success() && !output.stdout.is_empty() {
-        match serde_json::from_slice::<serde_json::Value>(&output.stdout) {
-            Ok(hook_output) => {
-                out.h1("Hook Output (Parsed)")?;
-                out.json(&hook_output)?;
-
-                out.h1("What Claude/User Would See")?;
-
-                // Parse decision field
-                if let Some(decision) = hook_output.get("decision").and_then(|d| d.as_str()) {
-                    match decision {
-                        "approve" => {
-                            out.write("Decision: ")?;
-                            out.success("APPROVE")?;
-                            out.newline()?;
-
-                            if let Some(reason) = hook_output.get("reason").and_then(|r| r.as_str())
-                            {
-                                out.label("User sees", reason)?;
-                                out.dimmed("Claude sees: (nothing, tool proceeds)")?;
-                            }
-                        }
-                        "block" => {
-                            out.write("Decision: ")?;
-                            out.error("BLOCK")?;
-                            out.newline()?;
-
-                            if let Some(reason) = hook_output.get("reason").and_then(|r| r.as_str())
-                            {
-                                out.label("User sees", "Tool blocked by hook")?;
-                                out.label("Claude sees", reason)?;
-                            }
-                        }
-                        _ => {
-                            out.label("Decision", &format!("Unknown ({decision})"))?;
-                        }
+                    if let Some(reason) = hook_output.get("reason").and_then(|r| r.as_str()) {
+                        out.label("User sees", reason)?;
+                        out.dimmed("Claude sees: (nothing, tool proceeds)")?;
                     }
-                } else {
-                    out.dimmed("Decision: NONE (follows normal permission flow)")?;
                 }
+                "block" => {
+                    out.write("Decision: ")?;
+                    out.error("BLOCK")?;
+                    out.newline()?;
 
-                if hook_output.get("continue").and_then(|c| c.as_bool()) == Some(false) {
-                    out.newline()?;
-                    out.error("Claude would STOP processing")?;
-                    out.newline()?;
-                    if let Some(reason) = hook_output.get("stopReason").and_then(|r| r.as_str()) {
-                        out.label("Stop reason shown to user", reason)?;
+                    if let Some(reason) = hook_output.get("reason").and_then(|r| r.as_str()) {
+                        out.label("User sees", "Tool blocked by hook")?;
+                        out.label("Claude sees", reason)?;
                     }
+                }
+                _ => {
+                    out.label("Decision", &format!("Unknown ({decision})"))?;
                 }
             }
-            Err(e) => {
-                out.h1("Hook Output (Raw - Failed to parse)")?;
-                out.block(String::from_utf8_lossy(&output.stdout).trim_end())?;
-                out.error(&format!("Parse error: {e}"))?;
-                out.newline()?;
+        } else {
+            out.dimmed("Decision: NONE (follows normal permission flow)")?;
+        }
+
+        if hook_output.get("continue").and_then(|c| c.as_bool()) == Some(false) {
+            out.newline()?;
+            out.error("Claude would STOP processing")?;
+            out.newline()?;
+            if let Some(reason) = hook_output.get("stopReason").and_then(|r| r.as_str()) {
+                out.label("Stop reason shown to user", reason)?;
             }
         }
     }

--- a/crates/hooktest/src/stop.rs
+++ b/crates/hooktest/src/stop.rs
@@ -1,7 +1,6 @@
+use crate::execute::execute_hook;
 use crate::output::Output;
 use anyhow::Result;
-use std::io::Write;
-use std::process::{Command, Stdio};
 use tenx_hooks::Stop;
 
 pub fn run_stop_hook(
@@ -22,113 +21,47 @@ pub fn run_stop_hook(
     // Serialize to JSON
     let input_json = serde_json::to_string(&hook_input)?;
 
-    // Execute the hook
-    if hook_args.is_empty() {
-        anyhow::bail!("No hook command provided. Use -- followed by the hook command.");
-    }
+    // Execute the hook and parse output
+    if let Some(hook_output) = execute_hook(
+        &mut out,
+        &hook_args,
+        &input_json,
+        &serde_json::to_value(&hook_input)?,
+    )? {
+        out.h1("What Claude/User Would See")?;
 
-    let mut cmd = Command::new(&hook_args[0]);
-    if hook_args.len() > 1 {
-        cmd.args(&hook_args[1..]);
-    }
-
-    out.h1("Running Hook")?;
-    out.label(
-        "Command",
-        &format!("{} {}", hook_args[0], hook_args[1..].join(" ")),
-    )?;
-
-    out.h1("Input JSON")?;
-    out.json(&serde_json::to_value(&hook_input)?)?;
-
-    out.h1("Execution")?;
-
-    let mut child = cmd
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    // Write input to stdin
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin.write_all(input_json.as_bytes())?;
-        stdin.flush()?;
-    }
-
-    // Wait for the process to complete
-    let output = child.wait_with_output()?;
-
-    let exit_code = output.status.code().unwrap_or(-1);
-    if output.status.success() {
-        out.label("Exit Code", &format!("{exit_code} "))?;
-        out.success("✓")?;
-        out.newline()?;
-    } else {
-        out.label("Exit Code", &format!("{exit_code} "))?;
-        out.error("✗")?;
-        out.newline()?;
-    }
-
-    if !output.stdout.is_empty() {
-        out.h1("STDOUT")?;
-        out.block(String::from_utf8_lossy(&output.stdout).trim_end())?;
-    }
-
-    if !output.stderr.is_empty() {
-        out.h1("STDERR")?;
-        out.dimmed(String::from_utf8_lossy(&output.stderr).trim_end())?;
-    }
-
-    // Parse the output if successful
-    if output.status.success() && !output.stdout.is_empty() {
-        match serde_json::from_slice::<serde_json::Value>(&output.stdout) {
-            Ok(hook_output) => {
-                out.h1("Hook Output (Parsed)")?;
-                out.json(&hook_output)?;
-
-                out.h1("What Claude/User Would See")?;
-
-                // Parse decision field
-                if let Some(decision) = hook_output.get("decision").and_then(|d| d.as_str()) {
-                    match decision {
-                        "block" => {
-                            out.write("Decision: ")?;
-                            out.error("BLOCK")?;
-                            out.newline()?;
-
-                            if let Some(reason) = hook_output.get("reason").and_then(|r| r.as_str())
-                            {
-                                out.label("Claude continues with", reason)?;
-                            }
-                        }
-                        _ => {
-                            out.label("Decision", &format!("Unknown ({decision})"))?;
-                        }
-                    }
-                } else {
-                    out.dimmed("Decision: NONE (Claude stops normally)")?;
-                }
-
-                if hook_output.get("continue").and_then(|c| c.as_bool()) == Some(false) {
+        // Parse decision field
+        if let Some(decision) = hook_output.get("decision").and_then(|d| d.as_str()) {
+            match decision {
+                "block" => {
+                    out.write("Decision: ")?;
+                    out.error("BLOCK")?;
                     out.newline()?;
-                    out.error("Claude would STOP processing")?;
-                    out.newline()?;
-                    if let Some(reason) = hook_output.get("stopReason").and_then(|r| r.as_str()) {
-                        out.label("Stop reason shown to user", reason)?;
+
+                    if let Some(reason) = hook_output.get("reason").and_then(|r| r.as_str()) {
+                        out.label("Claude continues with", reason)?;
                     }
                 }
-
-                if hook_output.get("suppressOutput").and_then(|s| s.as_bool()) == Some(true) {
-                    out.newline()?;
-                    out.dimmed("Output would be hidden in transcript mode")?;
+                _ => {
+                    out.label("Decision", &format!("Unknown ({decision})"))?;
                 }
             }
-            Err(e) => {
-                out.h1("Hook Output (Raw - Failed to parse)")?;
-                out.block(String::from_utf8_lossy(&output.stdout).trim_end())?;
-                out.error(&format!("Parse error: {e}"))?;
-                out.newline()?;
+        } else {
+            out.dimmed("Decision: NONE (Claude stops normally)")?;
+        }
+
+        if hook_output.get("continue").and_then(|c| c.as_bool()) == Some(false) {
+            out.newline()?;
+            out.error("Claude would STOP processing")?;
+            out.newline()?;
+            if let Some(reason) = hook_output.get("stopReason").and_then(|r| r.as_str()) {
+                out.label("Stop reason shown to user", reason)?;
             }
+        }
+
+        if hook_output.get("suppressOutput").and_then(|s| s.as_bool()) == Some(true) {
+            out.newline()?;
+            out.dimmed("Output would be hidden in transcript mode")?;
         }
     }
 


### PR DESCRIPTION
## Summary
- extract common hook execution logic into `execute_hook`
- update `run_pretooluse_hook`, `run_posttooluse_hook`, `run_notification_hook`, and `run_stop_hook` to use the new helper
- register the new module in `main.rs`

## Testing
- `cargo clippy --fix --allow-dirty --examples --tests`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68675a9965848333bb0e1da216326729