### PR TITLE
Update test scripts for new CLI flags

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,12 +18,6 @@ Tests the `dangerous_check` example with both safe and dangerous commands to dem
 ./scripts/test-dangerous.sh
 ```
 
-### test-with-cargo.sh
-Shows how to use `hooktest` with `cargo run` during development, useful when you're actively working on hooks.
-
-```bash
-./scripts/test-with-cargo.sh
-```
 
 ## Usage
 

--- a/scripts/test-dangerous.sh
+++ b/scripts/test-dangerous.sh
@@ -13,7 +13,7 @@ echo ""
     pretool \
     --sessionid safe-test-$(date +%s) \
     --tool Bash \
-    --input '{"command": "ls -la"}' \
+    --tool-input command="ls -la" \
     -- \
     ./target/debug/examples/dangerous_check
 
@@ -28,6 +28,6 @@ echo ""
     pretool \
     --sessionid danger-test-$(date +%s) \
     --tool Bash \
-    --input '{"command": "rm -rf /"}' \
+    --tool-input command="rm -rf /" \
     -- \
     ./target/debug/examples/dangerous_check

--- a/scripts/test-posttool.sh
+++ b/scripts/test-posttool.sh
@@ -16,8 +16,8 @@ echo "-------------------------------------------"
 cargo run --bin hooktest -- posttool \
     --sessionid "test-123" \
     --tool "Bash" \
-    --input '{"command": "ls -la"}' \
-    --response '{"output": "total 24\ndrwxr-xr-x  2 user user 4096 Jan 1 12:00 .\n"}' \
+    --tool-input command="ls -la" \
+    --tool-response output="total 24\ndrwxr-xr-x  2 user user 4096 Jan 1 12:00 .\n" \
     -- target/debug/examples/posttool_logger
 
 echo
@@ -29,8 +29,8 @@ echo "-------------------------------------------------"
 cargo run --bin hooktest -- posttool \
     --sessionid "test-456" \
     --tool "Bash" \
-    --input '{"command": "export DB_PASSWORD=secret123"}' \
-    --response '{"output": ""}' \
+    --tool-input command="export DB_PASSWORD=secret123" \
+    --tool-response output="" \
     -- target/debug/examples/posttool_logger
 
 echo
@@ -42,6 +42,6 @@ echo "-----------------------------"
 cargo run --bin hooktest -- posttool \
     --sessionid "test-789" \
     --tool "Read" \
-    --input '{"file_path": "/etc/hosts"}' \
-    --response '{"content": "127.0.0.1 localhost\n"}' \
+    --tool-input file_path="/etc/hosts" \
+    --tool-response content="127.0.0.1 localhost\n" \
     -- target/debug/examples/posttool_logger

--- a/scripts/test-precheck.sh
+++ b/scripts/test-precheck.sh
@@ -6,6 +6,6 @@ cargo build --example precheck --quiet
     pretool \
     --sessionid test-session-$(date +%s) \
     --tool Bash \
-    --input '{"command": "echo Hello from hooktest!"}' \
+    --tool-input command="echo Hello from hooktest!" \
     -- \
     ./target/debug/examples/precheck


### PR DESCRIPTION
## Summary
- update `test-precheck.sh`, `test-dangerous.sh`, and `test-posttool.sh` to use `--tool-input` and `--tool-response`
- strip outdated `test-with-cargo.sh` section from script README

## Testing
- `./scripts/test-precheck.sh`
- `./scripts/test-dangerous.sh`
- `./scripts/test-posttool.sh`
- `./scripts/test-notification.sh`
- `./scripts/test-stop.sh`

------
https://chatgpt.com/codex/tasks/task_e_6869aa75734883338d3ca92c953ae1c4