### PR TITLE
Add hooktest CLI integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,6 +74,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +99,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -101,6 +132,17 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -204,6 +246,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +287,15 @@ checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -279,13 +342,16 @@ name = "hooktest"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "atty",
  "clap",
  "claude-transcript",
  "code-hooks",
+ "predicates",
  "serde",
  "serde_json",
  "syntect",
+ "tempfile",
  "termcolor",
 ]
 
@@ -345,10 +411,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -410,6 +491,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +552,29 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-syntax"
@@ -589,6 +723,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +790,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/crates/hooktest/Cargo.toml
+++ b/crates/hooktest/Cargo.toml
@@ -18,3 +18,8 @@ claude-transcript = { path = "../claude-transcript" }
 termcolor = "1"
 syntect = "5"
 atty = "0.2"
+
+[dev-dependencies]
+assert_cmd = "2"
+tempfile = "3"
+predicates = "3"

--- a/crates/hooktest/tests/cli_tests.rs
+++ b/crates/hooktest/tests/cli_tests.rs
@@ -1,0 +1,95 @@
+use assert_cmd::prelude::*;
+use predicates::str::contains;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
+use tempfile::{NamedTempFile, TempPath};
+
+fn make_hook_script() -> TempPath {
+    let mut file = NamedTempFile::new().unwrap();
+    fs::write(
+        file.path(),
+        "#!/bin/sh\ncat >/dev/null\nprintf '{\"decision\":\"approve\",\"reason\":\"ok\"}'\n",
+    )
+    .unwrap();
+    fs::set_permissions(file.path(), fs::Permissions::from_mode(0o755)).unwrap();
+    file.into_temp_path()
+}
+
+#[test]
+fn test_help() {
+    Command::cargo_bin("hooktest")
+        .unwrap()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(contains("hooktest"));
+}
+
+#[test]
+fn test_pretool() {
+    let hook = make_hook_script();
+    Command::cargo_bin("hooktest")
+        .unwrap()
+        .args([
+            "pretool",
+            "--tool",
+            "Bash",
+            "--",
+            hook.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(contains("Decision: APPROVE"));
+}
+
+#[test]
+fn test_posttool() {
+    let hook = make_hook_script();
+    Command::cargo_bin("hooktest")
+        .unwrap()
+        .args([
+            "posttool",
+            "--tool",
+            "Bash",
+            "--tool-response",
+            "output=ok",
+            "--",
+            hook.to_path_buf().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(contains("Hook Output (Parsed)"));
+}
+
+#[test]
+fn test_notification() {
+    Command::cargo_bin("hooktest")
+        .unwrap()
+        .args(["notification", "--", "true"])
+        .assert()
+        .success()
+        .stdout(contains("Running Hook"));
+}
+
+#[test]
+fn test_stop() {
+    let hook = make_hook_script();
+    Command::cargo_bin("hooktest")
+        .unwrap()
+        .args(["stop", "--", hook.to_path_buf().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(contains("Hook Output (Parsed)"));
+}
+
+#[test]
+fn test_subagent_stop() {
+    let hook = make_hook_script();
+    Command::cargo_bin("hooktest")
+        .unwrap()
+        .args(["subagentstop", "--", hook.to_path_buf().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(contains("Hook Output (Parsed)"));
+}


### PR DESCRIPTION
## Summary
- exercise hooktest CLI with assert_cmd
- add test dependencies

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6869aa938b948333b4749377dc0b25dd