### PR TITLE
Move util helpers to dedicated module

### DIFF
--- a/crates/rust-hook/src/lib.rs
+++ b/crates/rust-hook/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod utils;
+
+pub use utils::{find_project_root, is_rust_file};

--- a/crates/rust-hook/src/main.rs
+++ b/crates/rust-hook/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use code_hooks::{HookResponse, Input, PostToolUse, PostToolUseOutput, Stop, TranscriptReader};
+use rust_hook::is_rust_file;
 use std::process::Command;
 
 #[derive(Parser)]
@@ -48,7 +49,7 @@ fn handle_posttool() -> Result<()> {
     eprintln!("[rust-hook] File path: {file_path}");
 
     // Check if the file is a Rust file
-    if !file_path.ends_with(".rs") {
+    if !is_rust_file(file_path) {
         eprintln!("[rust-hook] Not a Rust file, passing through");
         PostToolUseOutput::passthrough().respond();
     }
@@ -120,7 +121,7 @@ fn has_edited_rust_files(input: &Stop) -> Result<bool> {
                             .get("file_path")
                             .and_then(|v| v.as_str())
                         {
-                            if file_path.ends_with(".rs") {
+                            if is_rust_file(file_path) {
                                 eprintln!("[rust-hook] Found edited Rust file: {file_path}");
                                 return Ok(true);
                             }

--- a/crates/rust-hook/src/utils.rs
+++ b/crates/rust-hook/src/utils.rs
@@ -1,0 +1,24 @@
+use std::path::Path;
+
+/// Find the nearest ancestor directory containing a `Cargo.toml` file.
+/// Returns the directory path as a `String`.
+pub fn find_project_root(file_path: &str) -> String {
+    let path = Path::new(file_path);
+    let mut current = path.parent();
+
+    while let Some(dir) = current {
+        if dir.join("Cargo.toml").exists() {
+            return dir.to_string_lossy().to_string();
+        }
+        current = dir.parent();
+    }
+
+    path.parent()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|| ".".to_string())
+}
+
+/// Determine whether the provided path refers to a Rust source file.
+pub fn is_rust_file(file_path: &str) -> bool {
+    file_path.ends_with(".rs")
+}

--- a/crates/rust-hook/tests/integration_test.rs
+++ b/crates/rust-hook/tests/integration_test.rs
@@ -1,5 +1,5 @@
+use rust_hook::utils::{find_project_root, is_rust_file};
 use std::fs;
-use std::path::Path;
 use tempfile::TempDir;
 
 #[test]
@@ -70,25 +70,4 @@ fn test_subcommand_help() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("stop"));
-}
-
-// Helper functions copied from main.rs for testing
-fn find_project_root(file_path: &str) -> String {
-    let path = Path::new(file_path);
-    let mut current = path.parent();
-
-    while let Some(dir) = current {
-        if dir.join("Cargo.toml").exists() {
-            return dir.to_string_lossy().to_string();
-        }
-        current = dir.parent();
-    }
-
-    path.parent()
-        .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_else(|| ".".to_string())
-}
-
-fn is_rust_file(file_path: &str) -> bool {
-    file_path.ends_with(".rs")
 }


### PR DESCRIPTION
## Summary
- move util functions to `src/utils.rs`
- keep re-exports from `lib.rs`
- update usage in integration tests

## Testing
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_6869aaa2672c8333b1ec25cf31df7877